### PR TITLE
Add missing tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -16,9 +16,18 @@ describe('.omit()', function () {
     omit({a: 'a', b: 'b', c: 'c'}, 'a').should.eql({ b: 'b', c: 'c' });
   });
 
-  it('should omit the given keys from the object.', function () {
+  it('should omit the given keys as array from the object.', function () {
     omit({a: 'a', b: 'b', c: 'c'}, ['a', 'c']).should.eql({ b: 'b' });
   });
+
+  it('should omit the given keys as arrays from the object.', function () {
+    omit({a: 'a', b: 'b', c: 'c'}, ['a'], ['b', 'c']).should.eql({});
+  });
+
+  it('should omit the given keys as parameters from the object.', function () {
+    omit({a: 'a', b: 'b', c: 'c'}, 'a', 'c').should.eql({ b: 'b' });
+  });
+
 
   it('should return the object if no keys are specified.', function () {
     omit({a: 'a', b: 'b', c: 'c'}).should.eql({a: 'a', b: 'b', c: 'c'});


### PR DESCRIPTION
I don't understand this line: https://github.com/jonschlinkert/object.omit/commit/b23b2fd79473518dd81ce75a9a6bb64b7942abee#diff-168726dbe96b3ce427e7fedce31bb0bcR16

In enables the usage of object.fit that's not documented nor tested. Why wasn't the previous one enough (`.isArray, etc`)?

Additionally, the current usage of `arguments` [kills V8 optimization](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#what-is-safe-arguments-usage), so I suggest changing that line either way. Let me know if you'd like me to fix it by dropping this undocumented behavior or by using `.apply` before `.slice`

One more question: can Node 0.10 support be dropped?